### PR TITLE
Manually sort nuget package names

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,17 +1,17 @@
 <Project>
 
   <ItemGroup>
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.5.3" />
     <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.5.3" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="FluentValidation" Version="12.0.0" />
-    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Normally when we use vs nuget package manager ui or dotnet cli to install the nuget packages then it automatically sort the package names. But since I have installed the packages manually by editing the `Directory.Packages.props` file, so I need to sort those manually. It is not the full sort, I have only done the first letter sort.